### PR TITLE
Fix malformed filter in getProcessById method

### DIFF
--- a/src/RobbieP/CloudConvertLaravel/CloudConvert.php
+++ b/src/RobbieP/CloudConvertLaravel/CloudConvert.php
@@ -703,7 +703,7 @@ class CloudConvert
     private function getProcessById($id)
     {
         $process = $this->processes->filter(function ($item) use ($id) {
-            return $item->id = $id;
+            return $item->id === $id;
         })->first();
         return $process;
     }


### PR DESCRIPTION
The `getProcessById` filter would return the incorrect process due to reassigning values instead of comparing them.
