### PR TITLE
Expand Usage of Wait Function

### DIFF
--- a/src/RobbieP/CloudConvertLaravel/CloudConvert.php
+++ b/src/RobbieP/CloudConvertLaravel/CloudConvert.php
@@ -185,10 +185,10 @@ class CloudConvert
     {
         $this->mode = $mode;
         $this->startProcess();
-        $this->setOption('wait', $wait);
+        $this->wait($wait);
         $this->getProcess()->mode($mode, $this->getInput(), $this->getOutput());
 
-        if ($wait && $this->getProcess()->waitForConversion()) {
+        if ($this->getProcess()->waitForConversion()) {
             return $this;
         }
         return $this;
@@ -616,9 +616,9 @@ class CloudConvert
      * 
      * @return \RobbieP\CloudConvertLaravel\CloudConvert
      */
-    public function wait()
+    public function wait($value = true)
     {
-        $this->setOption('wait', true);
+        $this->setOption('wait', $value);
         return $this;
     }
 

--- a/src/RobbieP/CloudConvertLaravel/CloudConvert.php
+++ b/src/RobbieP/CloudConvertLaravel/CloudConvert.php
@@ -185,7 +185,7 @@ class CloudConvert
     {
         $this->mode = $mode;
         $this->startProcess();
-	$this->setOption('wait', $wait);
+        $this->setOption('wait', $wait);
         $this->getProcess()->mode($mode, $this->getInput(), $this->getOutput());
 
         if ($wait && $this->getProcess()->waitForConversion()) {

--- a/src/RobbieP/CloudConvertLaravel/CloudConvert.php
+++ b/src/RobbieP/CloudConvertLaravel/CloudConvert.php
@@ -181,14 +181,16 @@ class CloudConvert
      * @throws Exception
      * @internal param null $type
      */
-    public function mode($mode = null)
+    public function mode($mode = null, $wait = true)
     {
         $this->mode = $mode;
         $this->startProcess();
-        $this->wait();
+	if($wait) {
+	    $this->wait();
+	}
         $this->getProcess()->mode($mode, $this->getInput(), $this->getOutput());
 
-        if ($this->getProcess()->waitForConversion()) {
+        if ($wait && $this->getProcess()->waitForConversion()) {
             return $this;
         }
         return $this;

--- a/src/RobbieP/CloudConvertLaravel/CloudConvert.php
+++ b/src/RobbieP/CloudConvertLaravel/CloudConvert.php
@@ -185,9 +185,7 @@ class CloudConvert
     {
         $this->mode = $mode;
         $this->startProcess();
-	if($wait) {
-	    $this->wait();
-	}
+	$this->setOption('wait', $wait);
         $this->getProcess()->mode($mode, $this->getInput(), $this->getOutput());
 
         if ($wait && $this->getProcess()->waitForConversion()) {


### PR DESCRIPTION
This resolves an issue where it is not desired for the URL to hang while waiting for a conversion to come back completed. Currently HHVM closes open http connections after 30s and most connections take longer. We also have all of our connections running in a queue that polls the status url for percent complete and the wait change made in 2.3 removed our ability to do this in a modular way.
